### PR TITLE
chore(commitlint): add commitlint and husky

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,4 @@ src
 *.log
 *.swp
 package-lock.json
+commitlint.config.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ node_js:
   - "10"
   - "8"
   - "6"
+before_install:
+  # Create a master branch for commitlint
+  # https://github.com/conventional-changelog/commitlint/issues/6
+  - git remote set-branches origin master && git fetch
 deploy:
   on:
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ node_js:
   - "12"
   - "10"
   - "8"
-  - "6"
 before_install:
   # Create a master branch for commitlint
   # https://github.com/conventional-changelog/commitlint/issues/6

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2019 American Express Travel Related Services Company, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,either express
+ * or implied. See the License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'scope-case': [2, 'always', ['pascal-case', 'camel-case', 'kebab-case']],
+  },
+};

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "lint": "eslint ./ --ignore-path .eslintignore --ext .js",
     "pretest": "npm run lint",
     "test": "jest",
+    "test:git-history": "commitlint --from origin/master --to HEAD",
+    "posttest": "npm run test:git-history",
     "prepublishOnly": "npm run build"
   },
   "jest": {
@@ -37,11 +39,14 @@
   "devDependencies": {
     "@babel/cli": "^7.6.4",
     "@babel/core": "^7.6.4",
+    "@commitlint/cli": "^8.2.0",
+    "@commitlint/config-conventional": "^8.2.0",
     "amex-jest-preset": "^5.0.0",
     "babel-preset-amex": "^3.0.0",
     "coveralls": "^3.0.7",
     "eslint": "^6.5.1",
     "eslint-config-amex": "^11.1.0",
+    "husky": "^3.1.0",
     "immutable": "^4.0.0-rc.12",
     "jest": "^24.9.0",
     "redux": "^4.0.4",
@@ -52,5 +57,11 @@
     "immutable": "^3||^4",
     "redux": "^3||^4",
     "redux-immutable": "^4.0.0"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "npm test",
+      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
+    }
   }
 }


### PR DESCRIPTION
This adds commitlint along with husky. Furthermore, I added
```
before_install:
  # Create a master branch for commitlint
  # https://github.com/conventional-changelog/commitlint/issues/6
  - git remote set-branches origin master && git fetch
```
So travis does not break.