### PR TITLE
fix(peerDependencies): correct semver string for immutable v4 rc

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "rimraf": "^3.0.0"
   },
   "peerDependencies": {
-    "immutable": "^3||^4",
+    "immutable": "^3||^4.0.0-rc",
     "redux": "^3||^4",
     "redux-immutable": "^4.0.0"
   },


### PR DESCRIPTION
Closes #11 

If you go here: https://semver.npmjs.com/ and enter "immutable" and "^3||^4.0.0-rc" in the input boxes, you can verify this matches both version 3 and pre-release version 4.