### PR TITLE
test(lint): fix lint error after building

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 lib
 node_modules
 test-results
+immutable.js

--- a/immutable.js
+++ b/immutable.js
@@ -13,5 +13,4 @@
  */
 
 // Required file is only included in build
-// eslint-disable-next-line import/no-unresolved, import/extensions -- see above
 module.exports = require('./lib/immutable');


### PR DESCRIPTION
## Description
Do not lint the `immutable.js` file in the root.

## Motivation and Context
The `immutable.js` file imports a file from the `lib` dir.  This causes a lint paradox:
* If the lib dir doesn't exist, then eslint throws an error that you are importing from a non-existent thing.
* If you add a comment that says that's okay (what is in the code now), then eslint is happy again.  
* But now if you run a build, it will create the lib dir, and now there is no eslint error, and eslint complains you are disabling a rule for no reason.

So the easiest fix is to just not lint that file.

Other alternative fixes would be:
* Disable the two failing rules entirely.
* Run the clean script before the lint script, to ensure that lib dir isn't there.

## How Has This Been Tested?
Verified no eslint errors both when lib dir exists and doesn't exist.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] My changes are in sync with the code style of this project.
- [x] There aren't any other open Pull Requests for the same issue/update.
- [ ] These changes should be applied to a maintenance branch.
- [ ] This change requires cross browser checks.
- [ ] This change impacts caching for client browsers.
- [ ] This change adds additional environment variable requirements for vitruvius users.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using vitruvius?
None.