### PR TITLE
chore: limit packed files

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "3.0.1",
   "description": "Add buildInitialState method to your reducers",
   "main": "lib/index.js",
+  "files": [
+    "/lib"
+  ],
   "scripts": {
     "clean": "rimraf lib",
     "prebuild": "npm run test:lint && npm run clean",


### PR DESCRIPTION
## Description
Currently a bunch of junk is in the packed tar.gz like tests and github actions.

This changes to only include the lib dir plus other npm defaults.
```
$ npm pack

> @americanexpress/vitruvius@3.0.1 prepare
> husky install

husky - Git hooks installed
npm notice
npm notice 📦  @americanexpress/vitruvius@3.0.1
npm notice Tarball Contents
npm notice 10.3kB LICENSE.txt
npm notice 2.6kB README.md
npm notice 1.3kB lib/collectBuiltState.js
npm notice 1.5kB lib/immutable.js
npm notice 1.3kB lib/index.js
npm notice 2.0kB package.json
```